### PR TITLE
[IMP] web_m2x_options: Include min_length option

### DIFF
--- a/web_m2x_options/README.rst
+++ b/web_m2x_options/README.rst
@@ -60,6 +60,9 @@ New options
 
   A dictionary to link field value with a HTML color.
   This option has to be used with field_color.
+
+  ``min_length`` *int*
+    Minimum length of characters to run autocomplete.
   
 
 
@@ -104,12 +107,12 @@ Example
 Your XML form view definition could contain::
 
     ...
-    <field name="partner_id" options="{'limit': 10, 'create': false, 'create_edit': false, 'search_more':true 'field_color':'state', 'colors':{'active':'green'}}"/>
+    <field name="partner_id" options="{'limit': 10, 'create': false, 'create_edit': false, 'search_more':true 'field_color':'state', 'colors':{'active':'green'} 'min_length': 3}"/>
     ...
 
 Note
 ----
 
 Double check that you have no inherited view that remote ``options`` you set on a field ! 
-If nothing work, add a debugger in the first ligne of ``get_search_result method`` and enable debug mode in OpenERP. When you write something in a many2one field, javascript debugger should pause. If not verify your installation.
+If nothing work, add a debugger in the first line of ``get_search_result method`` and enable debug mode in OpenERP. When you write something in a many2one field, javascript debugger should pause. If not verify your installation.
 

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -91,12 +91,15 @@ openerp.web_m2x_options = function (instance) {
             var blacklist = this.get_search_blacklist();
             this.last_query = search_val;
 
-            var search_result = this.orderer.add(dataset.name_search(
+            var search_result = $.Deferred();
+            if (_.isUndefined(this.options.min_length) || (search_val.length >= parseInt(this.options.min_length))) {
+                search_result = this.orderer.add(dataset.name_search(
                 search_val,
                 new instance.web.CompoundDomain(
                     self.build_domain(), [["id", "not in", blacklist]]),
                 'ilike', this.limit + 1,
                 self.build_context()));
+            }
 
             var create_rights;
             if (!(self.options && (self.options.no_create || self.options.no_create_edit))) {


### PR DESCRIPTION
## Features
- Added a new option "min_length" for many2one fields (this option is recommended for those many2one with many records and take many time in loading)
- Added description in README file
