### PR TITLE
help_popup: Better look and feel for button

### DIFF
--- a/help_popup/__init__.py
+++ b/help_popup/__init__.py
@@ -1,1 +1,1 @@
-from . import model
+from . import models

--- a/help_popup/model.py
+++ b/help_popup/model.py
@@ -25,8 +25,9 @@ from openerp import models, fields
 class IrActionsActwindow(models.Model):
     _inherit = 'ir.actions.act_window'
 
-    enduser_help = fields.Html(
+    enduser_help = fields.Text(
         string="End User Help",
+        widget="html",
         help="Use this field to add custom content for documentation purpose\n"
              "mainly by power users ")
     advanced_help = fields.Text(

--- a/help_popup/models/__init__.py
+++ b/help_popup/models/__init__.py
@@ -1,0 +1,1 @@
+from . import ir_action

--- a/help_popup/models/ir_action.py
+++ b/help_popup/models/ir_action.py
@@ -29,8 +29,8 @@ class IrActionsActwindow(models.Model):
         string="End User Help",
         widget="html",
         help="Use this field to add custom content for documentation purpose\n"
-             "mainly by power users ")
+             "mainly for power users ")
     advanced_help = fields.Text(
         string="Advanced Help",
         help="Use this field to add custom content for documentation purpose\n"
-             "mainly by developers")
+             "mainly for developers")

--- a/help_popup/report/help.xml
+++ b/help_popup/report/help.xml
@@ -3,38 +3,28 @@
 <openerp>
 <data noupdate="1">
 
-<template id="tpl_help">
+    <template id="tpl_help">
 
-<t t-call="report.html_container">
-<t t-call="report.internal_layout">
+        <t t-call="report.layout">
+        <t t-foreach="docs" t-as="o">
 
+            <div class="container">
+                <div>
+                    <div t-if="o.enduser_help" class="panel panel-default" id="enduser_help">
+                        <div class="panel-heading"><h3>User Help</h3></div>
+                        <div class="panel-body" t-raw="o.enduser_help"/>
+                    </div>
+                    <div t-if="o.advanced_help" class="panel panel-default" id="advanced_help">
+                        <div class="panel-heading"><h3>Advanced Help</h3></div>
+                        <div class="panel-body" t-raw="o.advanced_help"/>
+                    </div>
+                </div>
+            </div>
 
-<t t-foreach="docs" t-as="o">
+        <!--end foreach-->
+        </t>
+        </t>
 
-<div class="page">
-
-<div t-raw="o.enduser_help"/>
-
-<hr width="70%"/>
-
-<h3 t-if="o.advanced_help">Help from developer</h3>
-<div t-raw="o.advanced_help"/>
-
-<hr width="70%"/>
-
-<h3 t-if="o.help">Help from Odoo</h3>
-<div t-raw="o.help"/>
-
-</div>
-
-<!--end foreach-->
-</t>
-
-</t>
-</t>
-
-</template>
-
-
+    </template>
 </data>
 </openerp>

--- a/help_popup/static/src/js/popup_help.js
+++ b/help_popup/static/src/js/popup_help.js
@@ -6,16 +6,14 @@ openerp.help_popup = function(instance, local) {
         do_create_view: function(view_type) {
             var self = this;
             var res = self._super(view_type);
-            self.$el.find('span.view_help').each(function () {
+            self.$el.find('.view_help').each(function () {
                 var $elem = $(this);
                 if ($elem.data('click-init')) {
                     return true;
                 }
                 $elem.data('click-init', true);
-                //alert('ee' + self.action)
-                console.log(self.action.id)
                 if (self.action.id == undefined || (self.action.advanced_help == '' && self.action.enduser_help == '')) {
-                    self.$el.find('span.view_help').hide()
+                    self.$el.find('.help_button').hide()
                 }
                 $elem.on('click', function(e) {
                     var params = 'height=650, width=800, location=no, ';
@@ -25,7 +23,6 @@ openerp.help_popup = function(instance, local) {
                     // allows to back to the window if opened previoulsy
                     setTimeout('my_window.focus()', 1);
                 });
-
                 return true;
 
             });

--- a/help_popup/static/src/js/popup_help.js
+++ b/help_popup/static/src/js/popup_help.js
@@ -14,6 +14,9 @@ openerp.help_popup = function(instance, local) {
                 $elem.data('click-init', true);
                 if (self.action.id == undefined || (self.action.advanced_help == '' && self.action.enduser_help == '')) {
                     self.$el.find('.help_button').hide()
+                    self.$el.find('.edit_help_button').show()
+                } else {
+                    self.$el.find('.edit_help_button').hide()
                 }
                 $elem.on('click', function(e) {
                     var params = 'height=650, width=800, location=no, ';
@@ -24,7 +27,16 @@ openerp.help_popup = function(instance, local) {
                     setTimeout('my_window.focus()', 1);
                 });
                 return true;
-
+            });
+            self.$el.find('.edit_help').each(function () {
+                var $elem = $(this);
+                if ($elem.data('click-init')) {
+                    return true;
+                }
+                $elem.data('click-init', true);
+                $elem.on('click', function(e) {
+                    alert('Hello World.');
+                });
             });
             return res;
         },

--- a/help_popup/static/src/xml/popup_help.xml
+++ b/help_popup/static/src/xml/popup_help.xml
@@ -1,8 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates>
-    <t t-name="ViewManagerAction" t-extend="ViewManagerAction">
-        <t t-jquery="h2.oe_view_title" t-operation="before">
-            <span> &amp;nbsp; </span><span class="oe_button oe_highlight view_help">?</span>
+    <t t-name="ViewManagerAction" t-extend="ViewManager">
+        <t t-jquery="ul.oe_view_manager_switch" t-operation="after">
+            <ul class="oe_view_manager_switch oe_button_group oe_right help_button">
+                <li class="oe_e">
+                    <a class="view_help">
+                        b
+                    </a>
+                </li>
+            </ul>
         </t>
     </t>
 </templates>

--- a/help_popup/static/src/xml/popup_help.xml
+++ b/help_popup/static/src/xml/popup_help.xml
@@ -9,6 +9,13 @@
                     </a>
                 </li>
             </ul>
+            <ul class="oe_view_manager_switch oe_button_group oe_right edit_help_button">
+                <li class="oe_e">
+                    <a class="edit_help">
+                        j
+                    </a>
+                </li>
+            </ul>
         </t>
     </t>
 </templates>

--- a/help_popup/views/action_view.xml
+++ b/help_popup/views/action_view.xml
@@ -1,18 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
     <data>
-
-<record id="view_window_action_form" model="ir.ui.view">
-    <field name="model">ir.actions.act_window</field>
-    <field name="inherit_id"
-           ref="base.view_window_action_form"/>
-    <field name="arch" type="xml">
-        <field name="help" position="after">
-            <field name="enduser_help"/>
-            <field name="advanced_help"/>
-        </field>
-    </field>
-</record>
-
+        <record id="view_window_action_form" model="ir.ui.view">
+            <field name="model">ir.actions.act_window</field>
+            <field name="inherit_id" ref="base.view_window_action_form"/>
+                <field name="arch" type="xml">
+                    <field name="help" position="after">
+                        <field name="enduser_help" widget="html"/>
+                        <field name="advanced_help"/>
+                    </field>
+                </field>
+        </record>
     </data>
 </openerp>


### PR DESCRIPTION
## Improvements on look and feel.

[IMP] help_popup: Better look and feel for button.
[FIX] Cleanup js, no necesary console and better jquery selector.

Before:
![](https://www.evernote.com/l/AJ4gkDXaQG1DNYnmIKz9EY8xRsk2YPfvAL0B/image.png)
After:
![](https://www.evernote.com/l/AJ6RxYNVY4tCN4asWC498r8xQnu7xnYqcFgB/image.png)
## Features added, TODO:
- [ ] End user can set a help with correct acl.
- [ ] En user can import a generated html in order to set the help.
- [ ] Glosary for fields help should be available on the windows.
- [ ] Try some popup text in order to set the help in popup.
- [ ] Appear in all views (even wizards) in order to show help in 100% of areas copying such feature from help_online.
