### PR TITLE
[FIX] web_widget_datepicker_options: Fix conditional typo

### DIFF
--- a/web_widget_datepicker_options/static/src/js/datepicker.js
+++ b/web_widget_datepicker_options/static/src/js/datepicker.js
@@ -34,7 +34,7 @@ odoo.define('web_widget_datepicker_options.datepicker', function(require) {
     Widget.DateTimeWidget.include({
         init: function() {
             this._super.apply(this, arguments);
-            if(typeof this.__parentedParent !== 'undefined' && this.__parentedParent.field.type === 'date' && this.__parentedParent.nodeOptions){
+            if(typeof this.__parentedParent !== 'undefined' && this.__parentedParent.field.type === 'datetime' && this.__parentedParent.nodeOptions){
                 var datepicker = this.__parentedParent.nodeOptions.datepicker;
                 Object.assign(this.options, datepicker);
             }


### PR DESCRIPTION
Currently, when the field to be modified is of type `datetime`, values
are not assigned due to a typo in the JS.

This change fixes that typo so the behavior is the expected