### PR TITLE
[FIX] web_widget_datepicker_options: Fix error when field is undefined

### DIFF
--- a/web_widget_datepicker_options/static/src/js/datepicker.js
+++ b/web_widget_datepicker_options/static/src/js/datepicker.js
@@ -11,6 +11,7 @@ odoo.define('web_widget_datepicker_options.datepicker', function(require) {
             this._super.apply(this, arguments);
             var parent = this.getParent();
             if(typeof parent !== 'undefined'
+                    && typeof parent.field !== 'undefined'
                     && parent.field.type === 'date'
                     && parent.nodeOptions){
                 var datepicker = parent.nodeOptions.datepicker;
@@ -24,6 +25,7 @@ odoo.define('web_widget_datepicker_options.datepicker', function(require) {
             this._super.apply(this, arguments);
             var parent = this.getParent();
             if(typeof parent !== 'undefined'
+                    && typeof parent.field !== 'undefined'
                     && parent.field.type === 'datetime'
                     && parent.nodeOptions){
                 var datepicker = parent.nodeOptions.datepicker;


### PR DESCRIPTION
Currently, when a view is rendered and a date or datetime field is not
defined (e.g. when designing reports), it causes a JS error.

This patch fixes the above error.

Closes #19 