### PR TITLE
[PATCH] requirements.txt: clear dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,1 @@
 # generated from manifests external_dependencies
-bokeh==2.3.1
-mpld3
-plotly==5.4.0


### PR DESCRIPTION
Because they're causing issues while resolving compatible versions.